### PR TITLE
Fix GPU device initialization

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -111,7 +111,8 @@ def init_net(net, init_type='normal', init_gain=0.02, gpu_ids=[]):
     """
     if len(gpu_ids) > 0:
         assert(torch.cuda.is_available())
-        net.to(gpu_ids[0])
+        device = torch.device('cuda:{}'.format(gpu_ids[0]))
+        net.to(device)
         net = torch.nn.DataParallel(net, gpu_ids)  # multi-GPUs
     init_weights(net, init_type, init_gain=init_gain)
     return net


### PR DESCRIPTION
## Summary
- register torch device before calling `.to()` when initializing networks

## Testing
- `python -m py_compile models/networks.py`


------
https://chatgpt.com/codex/tasks/task_e_6848cc05e1f0832a823018ce3464d520