### PR TITLE
Fix typos in option docs and base model

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -217,7 +217,7 @@ class BaseModel(ABC):
         print('-----------------------------------------------')
 
     def set_requires_grad(self, nets, requires_grad=False):
-        """Set requies_grad=Fasle for all the networks to avoid unnecessary computations
+        """Set requires_grad=False for all the networks to avoid unnecessary computations
         Parameters:
             nets (network list)   -- a list of networks
             requires_grad (bool)  -- whether the networks require gradients or not

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -14,7 +14,7 @@ class BaseOptions():
     """
 
     def __init__(self):
-        """Reset the class; indicates the class hasn't been initailized"""
+        """Reset the class; indicates the class hasn't been initialized."""
         self.initialized = False
 
     def initialize(self, parser):

--- a/options/test_options.py
+++ b/options/test_options.py
@@ -12,7 +12,7 @@ class TestOptions(BaseOptions):
         parser.add_argument('--results_dir', type=str, default='./results/', help='saves results here.')
         parser.add_argument('--aspect_ratio', type=float, default=1.0, help='aspect ratio of result images')
         parser.add_argument('--phase', type=str, default='test', help='train, val, test, etc')
-        # Dropout and Batchnorm has different behavioir during training and test.
+        # Dropout and Batchnorm has different behavior during training and test.
         parser.add_argument('--eval', action='store_true', help='use eval mode during test time.')
         parser.add_argument('--num_test', type=int, default=50, help='how many test images to run')
         # rewrite devalue values


### PR DESCRIPTION
## Summary
- fix grammar in BaseOptions initialization comment
- correct spelling in TestOptions comment
- clarify `requires_grad` description in BaseModel

## Testing
- `python -m py_compile options/base_options.py options/test_options.py models/base_model.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cd2c0fec832a99910e2f91985f7b