### PR TITLE
Fix scheduler NotImplementedError handling

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -61,7 +61,7 @@ def get_scheduler(optimizer, opt):
     elif opt.lr_policy == 'cosine':
         scheduler = lr_scheduler.CosineAnnealingLR(optimizer, T_max=opt.n_epochs, eta_min=0)
     else:
-        return NotImplementedError('learning rate policy [%s] is not implemented', opt.lr_policy)
+        raise NotImplementedError('learning rate policy [%s] is not implemented' % opt.lr_policy)
     return scheduler
 
 


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` instead of returning it in the scheduler helper

## Testing
- `python -m py_compile models/networks.py`
- *(failed: `import torch` not found when trying to import models)*

------
https://chatgpt.com/codex/tasks/task_e_6848cd33e454832ab8e3a537fc96c199