### PR TITLE
Fix docstring typo

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -188,7 +188,7 @@ def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', init_type='normal'
         [pixel]: 1x1 PixelGAN discriminator can classify whether a pixel is real or not.
         It encourages greater color diversity but has no effect on spatial statistics.
 
-    The discriminator has been initialized by <init_net>. It uses Leakly RELU for non-linearity.
+    The discriminator has been initialized by <init_net>. It uses Leaky ReLU.
     """
     net = None
     norm_layer = get_norm_layer(norm_type=norm)


### PR DESCRIPTION
## Summary
- fix typo in discriminator docstring

## Testing
- `python -m py_compile models/networks.py`

------
https://chatgpt.com/codex/tasks/task_e_6848cd3567f4832aa0b985dfbac86e06