### PR TITLE
Add test for scheduler error handling

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -61,7 +61,7 @@ def get_scheduler(optimizer, opt):
     elif opt.lr_policy == 'cosine':
         scheduler = lr_scheduler.CosineAnnealingLR(optimizer, T_max=opt.n_epochs, eta_min=0)
     else:
-        return NotImplementedError('learning rate policy [%s] is not implemented', opt.lr_policy)
+        raise NotImplementedError('learning rate policy [%s] is not implemented' % opt.lr_policy)
     return scheduler
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import types
+
+import torch
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from models import networks
+
+
+def test_get_scheduler_invalid_policy_raises():
+    optimizer = torch.optim.SGD([torch.tensor(1.0, requires_grad=True)], lr=0.1)
+    opt = types.SimpleNamespace(lr_policy="invalid")
+    with pytest.raises(NotImplementedError):
+        networks.get_scheduler(optimizer, opt)


### PR DESCRIPTION
## Summary
- ensure invalid learning rate policy raises NotImplementedError
- fix networks.get_scheduler to raise exception instead of returning it
- configure pytest to only look in the tests folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848cd36c04c832ab908e16376751f34