### PR TITLE
Adjust default batch size

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -72,11 +72,14 @@ class CustomDatasetDataLoader():
         dataset_class = find_dataset_using_name(opt.dataset_mode)
         self.dataset = dataset_class(opt)
         print("dataset [%s] was created" % type(self.dataset).__name__)
+        pin = opt.gpu_ids != '-1'
         self.dataloader = torch.utils.data.DataLoader(
             self.dataset,
             batch_size=opt.batch_size,
             shuffle=not opt.serial_batches,
-            num_workers=int(opt.num_threads))
+            num_workers=int(opt.num_threads),
+            drop_last=opt.isTrain,
+            pin_memory=pin)
 
     def load_data(self):
         return self

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -42,7 +42,7 @@ class BaseOptions():
         parser.add_argument('--direction', type=str, default='AtoB', help='AtoB or BtoA')
         parser.add_argument('--serial_batches', action='store_true', help='if true, takes images in order to make batches, otherwise takes them randomly')
         parser.add_argument('--num_threads', default=4, type=int, help='# threads for loading data')
-        parser.add_argument('--batch_size', type=int, default=1, help='input batch size')
+        parser.add_argument('--batch_size', type=int, default=8, help='input batch size')
         parser.add_argument('--load_size', type=int, default=286, help='scale images to this size')
         parser.add_argument('--crop_size', type=int, default=256, help='then crop to this size')
         parser.add_argument('--max_dataset_size', type=int, default=float("inf"), help='Maximum number of samples allowed per dataset. If the dataset directory contains more than max_dataset_size, only a subset is loaded.')

--- a/util/offline_metrics.py
+++ b/util/offline_metrics.py
@@ -42,12 +42,14 @@ def compute_ssim(real: np.ndarray, fake: np.ndarray) -> float:
     return float(structural_similarity(real, fake, channel_axis=2, data_range=1.0))
 
 
+@torch.no_grad()
 def compute_lpips(real: torch.Tensor, fake: torch.Tensor, lpips_fn: LearnedPerceptualImagePatchSimilarity) -> float:
     """Return LPIPS distance using the given LPIPS module."""
 
     return float(lpips_fn(fake.unsqueeze(0), real.unsqueeze(0)))
 
 
+@torch.no_grad()
 def compute_fid(real_paths: List[str], fake_paths: List[str], device: torch.device) -> float:
     """Compute FID over two image sets."""
 
@@ -59,6 +61,7 @@ def compute_fid(real_paths: List[str], fake_paths: List[str], device: torch.devi
     return float(fid.compute())
 
 
+@torch.no_grad()
 def compute_kid(real_paths: List[str], fake_paths: List[str], device: torch.device) -> float:
     """Compute KID over two image sets."""
 
@@ -70,6 +73,7 @@ def compute_kid(real_paths: List[str], fake_paths: List[str], device: torch.devi
     return float(kid.compute()[0])
 
 
+@torch.no_grad()
 def evaluate_pairwise(real_paths: List[str], fake_paths: List[str], device: torch.device) -> Dict[str, float]:
     """Evaluate standard metrics for two image lists."""
 


### PR DESCRIPTION
## Summary
- set `batch_size` default to 8 in `BaseOptions`
- optimize metrics with `torch.no_grad`
- drop last incomplete batch and pin memory for GPU in `CustomDatasetDataLoader`

## Testing
- `./run.sh` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*
- `pytest -q` *(fails: OSError: libtorch_global_deps.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_6848d40f44c0832a89dbe3b6a1175cc6